### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Tech Survey
+#
+# TODO: Needs "LABEL maintainer" added
+FROM alpine:3.6
+
+RUN apk add --update \
+    build-base \
+    ca-certificates \
+    freetype-dev \
+    gcc \
+    gfortran \
+    openblas-dev \
+    postgresql-dev \ 
+    python \
+    python-dev \
+    && python -m ensurepip
+
+RUN mkdir -p /opt/app
+
+COPY . /opt/app
+
+RUN cd /opt/app && \
+    pip install -r requirements.txt 
+
+WORKDIR /opt/app
+
+EXPOSE 5000
+
+CMD python manage.py requirements.txt
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
-The Cleveland Tech Survey
-======
+# The Cleveland Tech Survey
 
 Cleveland is a special place. Lots of the information provided by survey-type sites (Glassdoor, Stack Overflow, etc.) doesn't seem to accurately represent Cleveland. So the Cleveland Tech Survey is an attempt to help us learn more about what it's like to work in tech in Cleveland.
 
 Pull requests are welcome!
+
+## Development
+
+To run the application locally using a bare debian / ubuntu box (likely OSX too), make sure you have python-2.7.14 and pip installed.
+
+Install the pip requirements:
+
+```sh
+$ pip install -r requirements.txt
+```
+
+Start the server:
+
+```sh
+$ python manage.py runserver
+```` 
+
+or just run it in docker:
+
+```sh
+$ docker build -t tech-survey .
+$ docker run -it -name tech-survey -p 5000:5000 tech-survey
+```

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -96,5 +96,4 @@ virtualenvwrapper==4.7.2
 wcwidth==0.1.7
 Werkzeug==0.11.15
 WTForms==2.1
-xattr==0.6.4
 zope.interface==4.1.1


### PR DESCRIPTION
This change adds a Dockerfile to support local development and
production releases in containerized environments. The change itself
include documentation on how to start the docker container locally as
well as information on running the python application natively.

Support for the python module xattr was removed due to it not being used
and its lack of cross-platform support.